### PR TITLE
Upgraded composer to v2

### DIFF
--- a/compose/bin/devtools-cli-check
+++ b/compose/bin/devtools-cli-check
@@ -2,7 +2,6 @@
 if ! bin/clinotty ls /var/www/.composer-global/vendor/bin/cache-clean.js 1> /dev/null 2>&1; then
   echo "Installing devtools metapackage, just a moment..."
   bin/cliq mkdir -p /var/www/.composer-global
-  bin/composer init --working-dir=/var/www/.composer-global --quiet --no-interaction
   bin/composer require --working-dir=/var/www/.composer-global --quiet markshust/magento2-metapackage-devtools-cli:^1.0
   echo "Devtools installed."
 fi

--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -26,7 +26,6 @@ bin/clinotty chmod u+x bin/magento
 bin/setup-composer-auth
 
 echo "Forcing reinstall of composer deps to ensure perms & reqs..."
-bin/clinotty composer global require hirak/prestissimo
 bin/clinotty composer update
 
 echo "Waiting for connection to Elasticsearch..."

--- a/compose/images/php/Dockerfile
+++ b/compose/images/php/Dockerfile
@@ -86,11 +86,7 @@ RUN apt-get install -y msmtp mailutils
 COPY conf/msmtprc /etc/msmtprc
 
 RUN curl -sS https://getcomposer.org/installer | \
-  php -- --1 --install-dir=/usr/local/bin --filename=composer
-
-RUN mkdir /var/www/.composer-global \
-  && composer init --working-dir=/var/www/.composer-global --no-interaction \
-  && composer require --working-dir=/var/www/.composer-global markshust/magento2-metapackage-devtools-cli:^1.0
+  php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN curl -s https://packages.blackfire.io/gpg.key | apt-key add - \
   && echo "deb http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list \


### PR DESCRIPTION
### CHANGELOG

#### MODIFIED

- Composer to use v2 instead of v1

#### REMOVED

- `hirak/prestissimo` composer package as it's not needed when using Composer v2 (https://github.com/hirak/prestissimo#announcement-composer-2-is-now-available)